### PR TITLE
Prevents reading 'length' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,8 +61,8 @@ function parseMatchPage(url, callback) {
       round.away = parseInt($('.totals span.away.score', e).text(), 10);
     });
 
-    if (!ret.rounds.length) {
-      delete ret.rounds;
+    if (!ret.rounds || !ret.rounds.length) {
+      ret.rounds = null;
     }
 
     callback(null, ret);

--- a/test/index.js
+++ b/test/index.js
@@ -105,7 +105,7 @@ test('parses best-of-1 match page', function(t) {
     t.ok(isPlainObject(data));
     t.deepEqual(data, {
       home: {
-        name: 'LunatiK',
+        name: 'LunatiK: A',
         roster: [ 'flowsicK', 'valens', 'Relyks', 'Slemmy', 'autimatic' ]
       },
       away: {

--- a/test/index.js
+++ b/test/index.js
@@ -91,7 +91,8 @@ test('parses league match page', function(t) {
       },
       score1: 0,
       score2: 1,
-      date: 1411808400
+      date: 1411808400,
+      rounds: null
     });
   });
 });


### PR DESCRIPTION
Otherwise the script throws error on parsing live matches. 
Also, it's better to set to null, instead of deleting. Not just because of performance, but it's easier to have constant properties and have values or null.
